### PR TITLE
Kokkos: addding a section about the kokkos programming model

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -628,6 +628,30 @@ xeprint = {https://arc.aiaa.org/doi/pdf/10.2514/6.2019-2278}
   publisher={Wiley Online Library}
 }
 
+@article{trott2022kokkos,
+  author={Trott, Christian R. and Lebrun-Grandié, Damien and Arndt, Daniel and Ciesko, Jan and Dang, Vinh and Ellingwood, Nathan and Gayatri, Rahulkumar and Harvey, Evan and Hollman, Daisy S. and Ibanez, Dan and Liber, Nevin and Madsen, Jonathan and Miles, Jeff and Poliakoff, David and Powell, Amy and Rajamanickam, Sivasankaran and Simberg, Mikael and Sunderland, Dan and Turcksin, Bruno and Wilke, Jeremiah},
+  journal={IEEE Transactions on Parallel and Distributed Systems},
+  title={Kokkos 3: Programming Model Extensions for the Exascale Era},
+  year={2022},
+  volume={33},
+  number={4},
+  pages={805-817},
+  doi={10.1109/TPDS.2021.3097283}}
+
+@article{edwards2014,
+  title = "Kokkos: Enabling manycore performance portability through polymorphic memory access patterns ",
+  journal = "Journal of Parallel and Distributed Computing ",
+  volume = "74",
+  number = "12",
+  pages = "3202 - 3216",
+  year = "2014",
+  note = "Domain-Specific Languages and High-Level Frameworks for High-Performance Computing ",
+  issn = "0743-7315",
+  doi = "https://doi.org/10.1016/j.jpdc.2014.07.003",
+  url = "http://www.sciencedirect.com/science/article/pii/S0743731514001257",
+  author = "H. Carter Edwards and Christian R. Trott and Daniel Sunderland"
+}
+
 @article{trott2021kokkos,
   title={The Kokkos ecosystem: Comprehensive performance portability for high performance computing},
   author={Trott, Christian and Berger-Vergiat, Luc and Poliakoff, David and Rajamanickam, Sivasankaran and Lebrun-Grandie, Damien and Madsen, Jonathan and Al Awar, Nader and Gligoric, Milos and Shipman, Galen and Womeldorff, Geoff},

--- a/data_services.tex
+++ b/data_services.tex
@@ -4,18 +4,6 @@
 
 \todo{@Siva: do this!}
 
-One of the primary goals of Trilinos is to provide a performance portable stack of
-reusable scientific libraries. To that end todays iteration of Trilinos packages are
-leveraging the Kokkos Ecosystem to write harware agnostic code, that can efficiently
-execute on all major HPC architectures. While the Kokkos Ecosystem~\cite{trott2021kokkos}
-started as native Trilinos packages Kokkos and Kokkos Kernels, it split off a decade ago
-into a standalone project hosted at \url{https://github.com/kokkos}.
-However, Trilinos provides snapshots of the two primary Kokkos subprojects which reflect
-the latest release of Kokkos. Trilinos can also be build against version-compatible
-external installs of Kokkos - a capability required for interoperability with other
-Kokkos based libraries.
- 
-
 \subsection{Kokkos Core}\label{subsec:kokkos}
 Kokkos Core\footnote{For historical reasons the package name is "Kokkos" since it precedes the
 creation of other Kokkos subprojects such as Kokkos Kernels.} is a programming model

--- a/data_services.tex
+++ b/data_services.tex
@@ -4,32 +4,40 @@
 
 \todo{@Siva: do this!}
 
-\subsection{Kokkos}\label{subsec:kokkos}
-Kokkos is a programming model designed to allow performance portability across multiple
-hardware architectures such as CPU and GPU architectures. It was created in ahead of the
-diversification of compute hardware that was required to reach exascale computing
-platforms. It is targeting all major HPC platforms.
+One of the primary goals of Trilinos is to provide a performance portable stack of
+reusable scientific libraries. To that end todays iteration of Trilinos packages are
+leveraging the Kokkos Ecosystem to write harware agnostic code, that can efficiently
+execute on all major HPC architectures. While the Kokkos Ecosystem~\cite{trott2021kokkos}
+started as native Trilinos packages Kokkos and Kokkos Kernels, it split off a decade ago
+into a standalone project hosted at \url{https://github.com/kokkos}.
+However, Trilinos provides snapshots of the two primary Kokkos subprojects which reflect
+the latest release of Kokkos. Trilinos can also be build against version-compatible
+external installs of Kokkos - a capability required for interoperability with other
+Kokkos based libraries.
+ 
 
-To achieve this goal, Kokkos provides two abstractions, one for the parallel execution
-of code and one for the management of data. The parallel execution abstraction introduces
+\subsection{Kokkos Core}\label{subsec:kokkos}
+Kokkos Core\footnote{For historical reasons the package name is "Kokkos" since it precedes the
+creation of other Kokkos subprojects such as Kokkos Kernels.} is a programming model
+designed for performance portability across hardware architectures such as CPUs and GPUs.
+Two primary insights into achieving performance portability shaped Kokkos's development:
+i) abstractions for both parallel execution and data structures are required, and
+ii) the fundamental programming model must be descriptibe not prescriptive.
+
+The parallel execution include
 \texttt{execution spaces} to specify where an algorithm should run, \texttt{execution
 policies} to indicate how the algorithm should be run in terms of hardware resources and
 \texttt{execution patterns} to designate what pattern among \texttt{for, reduce, scan}
-will be used by the algorithms. The data management abstraction provides multiple data
-containers that specify where the underlying memory is allocated, how it is to be
-accessed and what objects are contained. The most prevalent containers of the Kokkos
-programming model is the Kokkos View.
-
-The Kokkos programming model is implemented in the Kokkos library and is developed in a
-separate GitHub repository\footnote{https://github.com/kokkos/kokkos}. Ahead of each
-release of the Kokkos ecosystem~\ref{trott2021kokkos}, the library is snapshoted in the
-Trilinos repository and integration with the other packages is performed. Additionally
-it is possible to build Trilinos against an externally installed Kokkos. In that case
-care needs to be taken to select a version of Kokkos that is compatible with the rest
-of Trilinos, in particular with the Tpetra package.
+will be used by the algorithms. The data structure abstractions are build around the
+concepts of \texttt{memory space} to indicate where memory is allocated,
+\texttt{memory layouts} to specify how data is layed out in memory, and \texttt{memory traits}
+that enable customizations of how data is accessed. The primary data structure incorporating
+these concepts is \texttt{Kokkos::View} - a multidimensional array abstractions that inspired
+the ISO C++23 \texttt{mdspan} class. Detailed descriptions of Kokkos Core can be found
+in~\cite{edwards2014} and \cite{trott2022kokkos}.
 
 \subsection{Kokkos Kernels}\label{subsec:kk}
-Kokkos Kernels~\cite{rajamanickam2021kokkoskernels} is part of the Kokkos ecosystem
+Kokkos Kernels~\cite{rajamanickam2021kokkoskernels} is part of the Kokkos Ecosystem
 ~\cite{trott2021kokkos} and provides node local implementations of mathematical kernels
 widely used across packages in Trilinos. As a member of the Kokkos
 ecosystem, Kokkos Kernels is tightly integrated on Kokkos features and aims at

--- a/data_services.tex
+++ b/data_services.tex
@@ -1,26 +1,22 @@
 % MMW: I'd order these subsections roughly in order of the software stack... most fundamental to most complex
 
-\todo{Describe performance portability... I think this should go into the intro section.}
-
-\todo{@Siva: do this!}
-
 \subsection{Kokkos Core}\label{subsec:kokkos}
-Kokkos Core\footnote{For historical reasons the package name is "Kokkos" since it precedes the
+Kokkos Core\footnote{For historical reasons the package name is ``Kokkos'' since it precedes the
 creation of other Kokkos subprojects such as Kokkos Kernels.} is a programming model
 designed for performance portability across hardware architectures such as CPUs and GPUs.
 Two primary insights into achieving performance portability shaped Kokkos's development:
 i) abstractions for both parallel execution and data structures are required, and
-ii) the fundamental programming model must be descriptibe not prescriptive.
+ii) the fundamental programming model must be descriptible not prescriptive.
 
 The parallel execution include
 \texttt{execution spaces} to specify where an algorithm should run, \texttt{execution
 policies} to indicate how the algorithm should be run in terms of hardware resources and
 \texttt{execution patterns} to designate what pattern among \texttt{for, reduce, scan}
-will be used by the algorithms. The data structure abstractions are build around the
+will be used by the algorithms. The data structure abstractions are built around the
 concepts of \texttt{memory space} to indicate where memory is allocated,
-\texttt{memory layouts} to specify how data is layed out in memory, and \texttt{memory traits}
+\texttt{memory layouts} to specify how data is laid out in memory, and \texttt{memory traits}
 that enable customizations of how data is accessed. The primary data structure incorporating
-these concepts is \texttt{Kokkos::View} - a multidimensional array abstractions that inspired
+these concepts is \texttt{Kokkos::View} - a multidimensional array abstraction that inspired
 the ISO C++23 \texttt{mdspan} class. Detailed descriptions of Kokkos Core can be found
 in~\cite{edwards2014} and \cite{trott2022kokkos}.
 

--- a/data_services.tex
+++ b/data_services.tex
@@ -4,6 +4,30 @@
 
 \todo{@Siva: do this!}
 
+\subsection{Kokkos}\label{subsec:kokkos}
+Kokkos is a programming model designed to allow performance portability across multiple
+hardware architectures such as CPU and GPU architectures. It was created in ahead of the
+diversification of compute hardware that was required to reach exascale computing
+platforms. It is targeting all major HPC platforms.
+
+To achieve this goal, Kokkos provides two abstractions, one for the parallel execution
+of code and one for the management of data. The parallel execution abstraction introduces
+\texttt{execution spaces} to specify where an algorithm should run, \texttt{execution
+policies} to indicate how the algorithm should be run in terms of hardware resources and
+\texttt{execution patterns} to designate what pattern among \texttt{for, reduce, scan}
+will be used by the algorithms. The data management abstraction provides multiple data
+containers that specify where the underlying memory is allocated, how it is to be
+accessed and what objects are contained. The most prevalent containers of the Kokkos
+programming model is the Kokkos View.
+
+The Kokkos programming model is implemented in the Kokkos library and is developed in a
+separate GitHub repository\footnote{https://github.com/kokkos/kokkos}. Ahead of each
+release of the Kokkos ecosystem~\ref{trott2021kokkos}, the library is snapshoted in the
+Trilinos repository and integration with the other packages is performed. Additionally
+it is possible to build Trilinos against an externally installed Kokkos. In that case
+care needs to be taken to select a version of Kokkos that is compatible with the rest
+of Trilinos, in particular with the Tpetra package.
+
 \subsection{Kokkos Kernels}\label{subsec:kk}
 Kokkos Kernels~\cite{rajamanickam2021kokkoskernels} is part of the Kokkos ecosystem
 ~\cite{trott2021kokkos} and provides node local implementations of mathematical kernels

--- a/introduction.tex
+++ b/introduction.tex
@@ -16,7 +16,32 @@ This article is an attempt to capture a snapshot of where Trilinos is today as o
 
 \todo{MMW: I think we should spend some time in this section outlining the motivation for our Kokkos approach, explaining the proliferation of node architectures, the Kokkos revolution, and what this has meant for Trilinos.  I think this is worth its own subsection. }
 
+One of the primary goals of modern Trilinos is to provide a performance portable stack of
+reusable scientific libraries, which enable users to write applications that are highly
+efficient on all modern High Performance Computing (HPC) hardware architectures.
 
+This goal emerged when the HPC architecture landscape started diversifying with the
+introduction of GPU acceleration for scientific software. Today 9 of the top 10 systems
+in the Top500 use GPUs, with only a single system being CPUs only.
+A complication in this shift is the diversification of vendor provided programming models.
+The aforementioned 10 system actually have four different preferred programming models:
+CUDA, HIP and OneAPI SYCL for the GPU based systems and OpenMP for the CPU system.
+
+To avoid the necessity of diverging code paths Trilinos is leveraging the Kokkos Ecosystem~\cite{trott2021kokkos}
+to write harware agnostic code. The Kokkos Ecosystem started as native Trilinos packages
+Kokkos and Kokkos Kernels but split off a decade ago into a standalone project hosted at \url{https://github.com/kokkos}.
+However, Trilinos provides snapshots of the two primary Kokkos subprojects which reflect
+the latest release of Kokkos. Trilinos can also be build against version-compatible
+external installs of Kokkos - a capability required for interoperability with other
+Kokkos based libraries.
+
+Kokkos enables Trilinos developers to write single source implementations of their packages,
+that perform well on all major HPC hardware architectures.
+Some of its design principles are also reflected in Trilinos API designs. In particular the
+use of \texttt{execution} and \texttt{memory spaces} as parameters of data structures and
+algorithms is a common thread through many packages.
+This design characteristic enables Trilinos users to manage the heterogenity of modern architectures
+and its impact of Trilinos data structures.
 
 \subsection{Trilinos Functionality}
 

--- a/introduction.tex
+++ b/introduction.tex
@@ -14,7 +14,7 @@ This article is an attempt to capture a snapshot of where Trilinos is today as o
 
 \subsection{Modern Trilinos}
 
-\todo{MMW: I think we should spend some time in this section outlining the motivation for our Kokkos approach, explaining the proliferation of node architectures, the Kokkos revolution, and what this has meant for Trilinos.  I think this is worth its own subsection. }
+%\todo{MMW: I think we should spend some time in this section outlining the motivation for our Kokkos approach, explaining the proliferation of node architectures, the Kokkos revolution, and what this has meant for Trilinos.  I think this is worth its own subsection. }
 
 One of the primary goals of modern Trilinos is to provide a performance portable stack of
 reusable scientific libraries, which enable users to write applications that are highly
@@ -23,25 +23,25 @@ efficient on all modern High Performance Computing (HPC) hardware architectures.
 This goal emerged when the HPC architecture landscape started diversifying with the
 introduction of GPU acceleration for scientific software. Today 9 of the top 10 systems
 in the Top500 use GPUs, with only a single system being CPUs only.
-A complication in this shift is the diversification of vendor provided programming models.
-The aforementioned 10 system actually have four different preferred programming models:
+A complication in this shift is the diversification of vendor-provided programming models.
+The aforementioned 10 systems actually have four different preferred programming models:
 CUDA, HIP and OneAPI SYCL for the GPU based systems and OpenMP for the CPU system.
 
-To avoid the necessity of diverging code paths Trilinos is leveraging the Kokkos Ecosystem~\cite{trott2021kokkos}
-to write harware agnostic code. The Kokkos Ecosystem started as native Trilinos packages
+To avoid the necessity of diverging code paths, Trilinos is leveraging the Kokkos Ecosystem~\cite{trott2021kokkos}
+to write hardware-agnostic code. The Kokkos Ecosystem started as native Trilinos packages
 Kokkos and Kokkos Kernels but split off a decade ago into a standalone project hosted at \url{https://github.com/kokkos}.
 However, Trilinos provides snapshots of the two primary Kokkos subprojects which reflect
-the latest release of Kokkos. Trilinos can also be build against version-compatible
-external installs of Kokkos - a capability required for interoperability with other
-Kokkos based libraries.
+the latest release of Kokkos. Trilinos can also be built against version-compatible
+external installations of Kokkos --- a capability required for interoperability with other
+Kokkos-based libraries.
 
 Kokkos enables Trilinos developers to write single source implementations of their packages,
 that perform well on all major HPC hardware architectures.
 Some of its design principles are also reflected in Trilinos API designs. In particular the
 use of \texttt{execution} and \texttt{memory spaces} as parameters of data structures and
 algorithms is a common thread through many packages.
-This design characteristic enables Trilinos users to manage the heterogenity of modern architectures
-and its impact of Trilinos data structures.
+This design characteristic enables Trilinos users to manage the heterogeneity of modern architectures
+and its impact on Trilinos data structures.
 
 \subsection{Trilinos Functionality}
 

--- a/main.tex
+++ b/main.tex
@@ -155,6 +155,8 @@
 \email{ccober@sandia.gov}
 \author{Heidi K. Thornquist}
 \email{hkthorn@sandia.gov}
+\author{Christian R. Trott}
+\email{crtrott@sandia.gov}
 \author{James M. Willenbring}
 \email{jmwille@sandia.gov}
 \orcid{0000-0002-0418-9264}


### PR DESCRIPTION
The section is adding in the data services general section. It currently focuses on the technical details of the Kokkos programming model itself. An additional section on the motivation for the Kokkos ecosystem, its impact on other Trilinos packages  and other aspects such as the HPSF can be added in the introduction as suggested by Michael.