### PR TITLE
Add outline of the manuscript

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -67,3 +67,9 @@ In the following sections of this paper, we group the Trilinos packages that sha
 \paragraph{Discretizations} This collection of packages provides functionality for the discretization of differential equations. In particular, it supports mesh-free and mesh-based spatial discretizations, with a focus on high-order finite elements, and time integration. Discretization tools also include cross-cutting utilities for algorithmic differentiation and for managing directed acyclic graphs of evaluation kernels. These capabilities are described further in Section~\ref{sec:discretization} in detail.
 
 \paragraph{Framework} The Framework product is different than the other Trilinos products in that most of the resources and services are not associated with Trilinos packages. The Framework product rather is focused primarily on activities such as developing and maintaining infrastructure for automated testing and documentation, as well as associated workflows. A small number of infrastructure and cross-cutting packages are also associated with the Framework, including Teuchos and PyTrilinos2. Section~\ref{sec:framework} provides further details.
+
+\subsection{Outline of this manuscript}
+
+Sections~\ref{sec:data_services} -- \ref{sec:framework} provide details on Trilinos' product areas.
+Section~\ref{sec:community} briefly touches upon the Trilinos community, software engineering aspects as well as the integration of Trilinos into the landscape of scientific software frameworks.
+Finally, Section~\ref{sec:conclusion} concludes the manuscript.


### PR DESCRIPTION
This PR adds a small section to the introduction giving a brief outline of the paper. The motivation is: Each section of a product area is mentioned in the brief description of the product are in "Trilinos Functionality". So far, the section on the "Trilinos Community" does not show up in the introduction. This PR fixes that.